### PR TITLE
flask-jwt-extended 4.7.1: rebuild py314

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
-
-channels:
-  - https://staging.continuum.io/pbp/fs/pyjwt-feedstock/pr7/1d67c52
-  - https://staging.continuum.io/pbp/fs/blinker-feedstock/pr11/e35bb96
-  - https://staging.continuum.io/pbp/fs/click-feedstock/pr15/3b84e96

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,3 +4,4 @@ build_env_vars:
 channels:
   - https://staging.continuum.io/pbp/fs/pyjwt-feedstock/pr7/1d67c52
   - https://staging.continuum.io/pbp/fs/blinker-feedstock/pr11/e35bb96
+  - https://staging.continuum.io/pbp/fs/click-feedstock/pr15/3b84e96

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,4 @@ build_env_vars:
 
 channels:
   - https://staging.continuum.io/pbp/fs/pyjwt-feedstock/pr7/1d67c52
+  - https://staging.continuum.io/pbp/fs/blinker-feedstock/pr11/e35bb96

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
+
+channels:
+  - https://staging.continuum.io/pbp/fs/pyjwt-feedstock/pr7/1d67c52

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
   run:
     - python
     - werkzeug >=0.14
-    - flask >=2.0,<4.0
+    - flask >=2.3.0,<4.0
     - pyjwt >=2.0,<3.0
     - cryptography >=3.3.1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,8 +22,13 @@ requirements:
     - setuptools
   run:
     - python
-    - werkzeug >=0.14
-    - flask >=2.3.0,<4.0
+    - werkzeug >=0.14  # [py<314]
+    # An error occurs when using werkzeug <3.0.0 for python 3.14:
+    # ImportError: cannot import name 'url_quote' from 'werkzeug.urls'.
+    # This is fixed in werkzeug 3.0.0+ and flask 3.0.0+.
+    - werkzeug >=3.0.0,<4.0.0  # [py>=314]
+    - flask >=2.0,<4.0  # [py<314]
+    - flask >=3.0,<4.0  # [py>=314]
     - pyjwt >=2.0,<3.0
     - cryptography >=3.3.1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,11 +23,11 @@ requirements:
   run:
     - python
     - werkzeug >=0.14  # [py<314]
+    - flask >=2.0,<4.0  # [py<314]
     # An error occurs when using werkzeug <3.0.0 for python 3.14:
     # ImportError: cannot import name 'url_quote' from 'werkzeug.urls'.
     # This is fixed in werkzeug 3.0.0+ and flask 3.0.0+.
     - werkzeug >=3.0.0,<4.0.0  # [py>=314]
-    - flask >=2.0,<4.0  # [py<314]
     - flask >=3.0,<4.0  # [py>=314]
     - pyjwt >=2.0,<3.0
     - cryptography >=3.3.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,12 +6,12 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name|lower|replace('-', '_') }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|lower|replace('-', '_') }}-{{ version }}.tar.gz
   sha256: 8085d6757505b6f3291a2638c84d207e8f0ad0de662d1f46aa2f77e658a0c976
 
 build:
-  skip: True  # [py<39]
-  number: 0
+  skip: true  # [py<39]
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
@@ -53,7 +53,7 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: 'A Flask JWT extension'
+  summary: A Flask JWT extension
   description: |
     Flask-JWT-Extended not only adds support for using JSON Web Tokens (JWT) to Flask for protecting routes,
     but also many helpful (and optional) features built in to make working with JSON Web Tokens easier.


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-10932) 
- [Upstream repository](https://github.com/vimalloc/flask-jwt-extended/tree/4.7.1)

### Explanation of changes:

- An error occurs when using `werkzeug <3.0.0` for python 3.14: `ImportError: cannot import name 'url_quote' from 'werkzeug.urls'.` This is changed in werkzeug 3.0.0+ and flask 3.0.0+.

### Notes:

-